### PR TITLE
fix missing return statement in transliterate

### DIFF
--- a/ext/icunicode.c
+++ b/ext/icunicode.c
@@ -102,7 +102,7 @@ static VALUE unicode_transliterate(int argc, VALUE *argv, VALUE string) {
   trans = get_trans(transform);
   utrans_transUChars(trans, str, &slen, BUF_SIZE, 0, &slen, &status);
 
-  to_utf8(str, slen);
+  return to_utf8(str, slen);
 }
 
 void Init_icunicode() {


### PR DESCRIPTION
newer compilers are returning **false** from String#transliterate calls